### PR TITLE
Remove unnecessary reference to a context inside adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.60'
+    ext.kotlin_version = '1.2.61'
     repositories {
         google()
         jcenter()

--- a/core/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/core/adapters/RecyclerAdapter.kt
+++ b/core/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/core/adapters/RecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.core.adapters
 
-import android.content.Context
 import android.support.v7.widget.RecyclerView
 import android.util.SparseBooleanArray
 import android.view.View
@@ -12,7 +11,7 @@ import com.github.stephenvinouze.advancedrecyclerview.core.views.BaseViewHolder
 /**
  * Created by Stephen Vinouze on 09/11/2015.
  */
-abstract class RecyclerAdapter<MODEL>(protected val context: Context) : RecyclerView.Adapter<BaseViewHolder>() {
+abstract class RecyclerAdapter<MODEL>() : RecyclerView.Adapter<BaseViewHolder>() {
 
     val selectedItemViewCount: Int
         get() = selectedItemViews.size()

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SampleAdapter.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SampleAdapter.java
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.javasample.adapters;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,14 +13,10 @@ import com.github.stephenvinouze.advancedrecyclerview.javasample.views.SampleIte
  */
 public class SampleAdapter extends RecyclerAdapter<Sample> {
 
-    public SampleAdapter(Context context) {
-        super(context);
-    }
-
     @NonNull
     @Override
     protected View onCreateItemView(@NonNull ViewGroup parent, int viewType) {
-        return new SampleItemView(getContext());
+        return new SampleItemView(parent.getContext());
     }
 
     @Override

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SamplePaginationAdapter.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SamplePaginationAdapter.java
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.javasample.adapters;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,20 +17,16 @@ import org.jetbrains.annotations.NotNull;
 
 public class SamplePaginationAdapter extends RecyclerPaginationAdapter<Sample> {
 
-    public SamplePaginationAdapter(Context context) {
-        super(context);
-    }
-
     @NotNull
     @Override
     protected View onCreateItemView(@NotNull ViewGroup parent, int viewType) {
-        return new SampleItemView(getContext());
+        return new SampleItemView(parent.getContext());
     }
 
     @NotNull
     @Override
     protected View onCreateLoaderView(@NotNull ViewGroup parent, int viewType) {
-        return LayoutInflater.from(getContext()).inflate(R.layout.view_progress, parent, false);
+        return LayoutInflater.from(parent.getContext()).inflate(R.layout.view_progress, parent, false);
     }
 
     @Override

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SampleSectionAdapter.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/adapters/SampleSectionAdapter.java
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.javasample.adapters;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,14 +14,14 @@ import com.github.stephenvinouze.advancedrecyclerview.section.adapters.RecyclerS
  */
 public class SampleSectionAdapter extends RecyclerSectionAdapter<Integer, Sample> {
 
-    public SampleSectionAdapter(Context context) {
-        super(context, (Sample::getRate));
+    public SampleSectionAdapter() {
+        super(Sample::getRate);
     }
 
     @NonNull
     @Override
     protected View onCreateItemView(@NonNull ViewGroup parent, int viewType) {
-        return new SampleItemView(getContext());
+        return new SampleItemView(parent.getContext());
     }
 
     @Override
@@ -34,7 +33,7 @@ public class SampleSectionAdapter extends RecyclerSectionAdapter<Integer, Sample
     @NonNull
     @Override
     public View onCreateSectionItemView(@NonNull ViewGroup parent, int viewType) {
-        return new SampleSectionItemView(getContext());
+        return new SampleSectionItemView(parent.getContext());
     }
 
     @Override

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/GestureRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/GestureRecyclerFragment.java
@@ -19,7 +19,7 @@ public class GestureRecyclerFragment extends AbstractRecyclerFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final SampleAdapter adapter = new SampleAdapter(getContext());
+        final SampleAdapter adapter = new SampleAdapter();
         adapter.setItems(Sample.mockItems());
 
         recyclerView.setAdapter(adapter);

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/GestureSectionRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/GestureSectionRecyclerFragment.java
@@ -24,7 +24,7 @@ public class GestureSectionRecyclerFragment extends AbstractRecyclerFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        final SampleSectionAdapter sectionAdapter = new SampleSectionAdapter(getContext());
+        final SampleSectionAdapter sectionAdapter = new SampleSectionAdapter();
         sectionAdapter.setChoiceMode(ChoiceMode.MULTIPLE);
         sectionAdapter.setOnClick((view1, position) -> {
             Sample sample = sectionAdapter.getItems().get(position);

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/MultipleChoiceRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/MultipleChoiceRecyclerFragment.java
@@ -19,7 +19,7 @@ public class MultipleChoiceRecyclerFragment extends AbstractRecyclerFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final SampleAdapter adapter = new SampleAdapter(getContext());
+        final SampleAdapter adapter = new SampleAdapter();
         adapter.setItems(Sample.mockItems());
         adapter.setChoiceMode(ChoiceMode.MULTIPLE);
         adapter.setOnClick((view1, position) -> {

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/PaginationRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/PaginationRecyclerFragment.java
@@ -38,7 +38,7 @@ public class PaginationRecyclerFragment extends AbstractRecyclerFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        paginationAdapter = new SamplePaginationAdapter(getContext());
+        paginationAdapter = new SamplePaginationAdapter();
 
         configureRecyclerView(view.findViewById(R.id.recycler_view));
         recyclerView.setAdapter(paginationAdapter);

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/SectionRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/SectionRecyclerFragment.java
@@ -18,7 +18,7 @@ public class SectionRecyclerFragment extends AbstractRecyclerFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final SampleSectionAdapter sectionAdapter = new SampleSectionAdapter(getContext());
+        final SampleSectionAdapter sectionAdapter = new SampleSectionAdapter();
         sectionAdapter.setChoiceMode(ChoiceMode.NONE);
         sectionAdapter.setItems(Sample.mockItems());
 

--- a/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/SingleChoiceRecyclerFragment.java
+++ b/javasample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/javasample/fragments/SingleChoiceRecyclerFragment.java
@@ -19,7 +19,7 @@ public class SingleChoiceRecyclerFragment extends AbstractRecyclerFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final SampleAdapter adapter = new SampleAdapter(getContext());
+        final SampleAdapter adapter = new SampleAdapter();
         adapter.setChoiceMode(ChoiceMode.SINGLE);
         adapter.setItems(Sample.mockItems());
         adapter.setOnClick((view1, position) -> {

--- a/pagination/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/pagination/adapters/RecyclerPaginationAdapter.kt
+++ b/pagination/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/pagination/adapters/RecyclerPaginationAdapter.kt
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.pagination.adapters
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import com.github.stephenvinouze.advancedrecyclerview.core.adapters.RecyclerAdapter
@@ -9,7 +8,7 @@ import com.github.stephenvinouze.advancedrecyclerview.core.views.BaseViewHolder
 /**
  * Created by stephenvinouze on 10/11/2017.
  */
-abstract class RecyclerPaginationAdapter<MODEL>(context: Context) : RecyclerAdapter<MODEL>(context) {
+abstract class RecyclerPaginationAdapter<MODEL> : RecyclerAdapter<MODEL>() {
 
     companion object {
         private const val LOADING_VIEW_TYPE = 111

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SampleAdapter.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SampleAdapter.kt
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.sample.adapters
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import com.github.stephenvinouze.advancedrecyclerview.core.adapters.RecyclerAdapter
@@ -10,9 +9,9 @@ import com.github.stephenvinouze.advancedrecyclerview.sample.views.SampleItemVie
 /**
  * Created by Stephen Vinouze on 09/11/2015.
  */
-open class SampleAdapter(context: Context) : RecyclerAdapter<Sample>(context) {
+open class SampleAdapter : RecyclerAdapter<Sample>() {
 
-    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(context)
+    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(parent.context)
 
     override fun onBindItemView(view: View, position: Int) {
         when (view) {

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SamplePaginationAdapter.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SamplePaginationAdapter.kt
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.sample.adapters
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,9 +11,9 @@ import com.github.stephenvinouze.advancedrecyclerview.sample.views.SampleItemVie
 /**
  * Created by stephenvinouze on 14/11/2017.
  */
-class SamplePaginationAdapter(context: Context) : RecyclerPaginationAdapter<Sample>(context) {
+class SamplePaginationAdapter : RecyclerPaginationAdapter<Sample>() {
 
-    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(context)
+    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(parent.context)
 
     override fun onBindItemView(view: View, position: Int) {
         when (view) {
@@ -23,6 +22,6 @@ class SamplePaginationAdapter(context: Context) : RecyclerPaginationAdapter<Samp
     }
 
     override fun onCreateLoaderView(parent: ViewGroup, viewType: Int): View =
-            LayoutInflater.from(context).inflate(R.layout.view_progress, parent, false)
+            LayoutInflater.from(parent.context).inflate(R.layout.view_progress, parent, false)
 
 }

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SampleSectionAdapter.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/adapters/SampleSectionAdapter.kt
@@ -1,9 +1,7 @@
 package com.github.stephenvinouze.advancedrecyclerview.sample.adapters
 
-import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-
 import com.github.stephenvinouze.advancedrecyclerview.sample.models.Sample
 import com.github.stephenvinouze.advancedrecyclerview.sample.views.SampleItemView
 import com.github.stephenvinouze.advancedrecyclerview.sample.views.SampleSectionItemView
@@ -12,9 +10,9 @@ import com.github.stephenvinouze.advancedrecyclerview.section.adapters.RecyclerS
 /**
  * Created by Stephen Vinouze on 09/11/2015.
  */
-class SampleSectionAdapter(context: Context) : RecyclerSectionAdapter<Int, Sample>(context, { it.rate }) {
+class SampleSectionAdapter : RecyclerSectionAdapter<Int, Sample>({ it.rate }) {
 
-    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(context)
+    override fun onCreateItemView(parent: ViewGroup, viewType: Int): View = SampleItemView(parent.context)
 
     override fun onBindItemView(view: View, position: Int) {
         when (view) {
@@ -23,7 +21,7 @@ class SampleSectionAdapter(context: Context) : RecyclerSectionAdapter<Int, Sampl
     }
 
     override fun onCreateSectionItemView(parent: ViewGroup, viewType: Int): View =
-            SampleSectionItemView(context)
+            SampleSectionItemView(parent.context)
 
     override fun onBindSectionItemView(sectionView: View, sectionPosition: Int) {
         sectionAt(sectionPosition)?.let {

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/GestureRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/GestureRecyclerFragment.kt
@@ -16,7 +16,7 @@ class GestureRecyclerFragment : AbstractRecyclerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val adapter = SampleAdapter(context!!).apply {
+        val adapter = SampleAdapter().apply {
             items = Sample.mockItems()
         }
 

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/GestureSectionRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/GestureSectionRecyclerFragment.kt
@@ -18,7 +18,7 @@ class GestureSectionRecyclerFragment : AbstractRecyclerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val sectionAdapter = SampleSectionAdapter(context!!).apply {
+        val sectionAdapter = SampleSectionAdapter().apply {
             items = Sample.mockItems().sortedBy { it.rate }.toMutableList()
             choiceMode = ChoiceMode.MULTIPLE
             onClick = { _, position ->

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/MultipleChoiceRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/MultipleChoiceRecyclerFragment.kt
@@ -16,7 +16,7 @@ class MultipleChoiceRecyclerFragment : AbstractRecyclerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val adapter = SampleAdapter(context!!).apply {
+        val adapter = SampleAdapter().apply {
             items = Sample.mockItems()
             choiceMode = ChoiceMode.MULTIPLE
             onClick = { _, position ->

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/PaginationRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/PaginationRecyclerFragment.kt
@@ -23,7 +23,7 @@ class PaginationRecyclerFragment : Fragment() {
     private val handler = Handler()
 
     private val paginationAdapter: SamplePaginationAdapter by lazy {
-        SamplePaginationAdapter(context!!)
+        SamplePaginationAdapter()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/SectionRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/SectionRecyclerFragment.kt
@@ -15,7 +15,7 @@ class SectionRecyclerFragment : AbstractRecyclerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val sectionAdapter = SampleSectionAdapter(context!!).apply {
+        val sectionAdapter = SampleSectionAdapter().apply {
             choiceMode = ChoiceMode.NONE
             items = Sample.mockItems()
         }

--- a/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/SingleChoiceRecyclerFragment.kt
+++ b/sample/src/main/java/com/github/stephenvinouze/advancedrecyclerview/sample/fragments/SingleChoiceRecyclerFragment.kt
@@ -16,7 +16,7 @@ class SingleChoiceRecyclerFragment : AbstractRecyclerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val adapter = SampleAdapter(context!!).apply {
+        val adapter = SampleAdapter().apply {
             choiceMode = ChoiceMode.SINGLE
             items = Sample.mockItems()
             onClick = { _, position ->

--- a/section/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/section/adapters/RecyclerSectionAdapter.kt
+++ b/section/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/section/adapters/RecyclerSectionAdapter.kt
@@ -10,7 +10,7 @@ import java.util.*
 /**
  * Created by Stephen Vinouze on 09/11/2015.
  */
-abstract class RecyclerSectionAdapter<SECTION, MODEL>(var section: (MODEL) -> SECTION) : RecyclerAdapter<MODEL>() {
+abstract class RecyclerSectionAdapter<SECTION : Comparable<SECTION>, MODEL>(var section: (MODEL) -> SECTION) : RecyclerAdapter<MODEL>() {
 
     companion object {
         private const val SECTION_VIEW_TYPE = 222
@@ -22,7 +22,7 @@ abstract class RecyclerSectionAdapter<SECTION, MODEL>(var section: (MODEL) -> SE
     val sections: List<SECTION>
         get() = sectionItems.keys.toList()
 
-    private var sectionItems: LinkedHashMap<SECTION, MutableList<MODEL>> = linkedMapOf()
+    private var sectionItems: SortedMap<SECTION, List<MODEL>> = sortedMapOf()
 
     override var items: MutableList<MODEL> = mutableListOf()
         set(value) {
@@ -92,16 +92,7 @@ abstract class RecyclerSectionAdapter<SECTION, MODEL>(var section: (MODEL) -> SE
     fun sectionAt(position: Int): SECTION? = sections[position]
 
     fun buildSections(items: List<MODEL>, section: (MODEL) -> SECTION) {
-        sectionItems = linkedMapOf()
-
-        items.forEach {
-            val itemSection = section(it)
-            val itemsInSection = sectionItems[itemSection] ?: arrayListOf()
-
-            itemsInSection.add(it)
-
-            sectionItems[itemSection] = itemsInSection
-        }
+        sectionItems = items.groupBy(section).toSortedMap()
     }
 
     /**

--- a/section/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/section/adapters/RecyclerSectionAdapter.kt
+++ b/section/src/main/kotlin/com/github/stephenvinouze/advancedrecyclerview/section/adapters/RecyclerSectionAdapter.kt
@@ -1,6 +1,5 @@
 package com.github.stephenvinouze.advancedrecyclerview.section.adapters
 
-import android.content.Context
 import android.support.v7.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
@@ -11,7 +10,7 @@ import java.util.*
 /**
  * Created by Stephen Vinouze on 09/11/2015.
  */
-abstract class RecyclerSectionAdapter<SECTION, MODEL>(context: Context, var section: (MODEL) -> SECTION) : RecyclerAdapter<MODEL>(context) {
+abstract class RecyclerSectionAdapter<SECTION, MODEL>(var section: (MODEL) -> SECTION) : RecyclerAdapter<MODEL>() {
 
     companion object {
         private const val SECTION_VIEW_TYPE = 222


### PR DESCRIPTION
Holding the reference to the context is not a best practice. 
I prefer using `parent.context` which is not optional during view creation
This also avoid the force unwrap of the context inside fragment.